### PR TITLE
HF-50: 카카오 로그인 api 작성

### DIFF
--- a/gible/src/api/axios.js
+++ b/gible/src/api/axios.js
@@ -1,6 +1,8 @@
 import axios from 'axios'
 import { apiServer } from '@/config/api'
 
-export const axios = axios.create({
+const apiClient = axios.create({
     baseURL: apiServer
 })
+
+export default apiClient;

--- a/gible/src/components/login/Redirection.js
+++ b/gible/src/components/login/Redirection.js
@@ -12,7 +12,7 @@ const Redirection = () => {
     useEffect(() => {
         /*
           apiClient.post('/kakaologin', {
-            clientId : loginConfig.CLIENT_ID,
+            clientId : loginConfig.REST_API_KEY,
             code
           })
         */

--- a/gible/src/components/login/Redirection.js
+++ b/gible/src/components/login/Redirection.js
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom';
+import loginConfig from '@/config/loginConfig'
+import apiClient from '@/api/axios';
+import Loading from '@/layouts/Loading';
+
+const Redirection = () => {
+    const code = new URL(document.location.toString()).searchParams.get('code');
+    const navigate = useNavigate();
+    const [isLoaded, setIsLoaded] = useState(false);
+  
+    useEffect(() => {
+        /*
+          apiClient.post('/kakaologin', {
+            clientId : loginConfig.CLIENT_ID,
+            code
+          })
+        */
+      
+        // response받아서 setIsLoaded 호출
+    
+        navigate('/');
+    }, [])
+
+  return (
+      <div>
+        {(!isLoaded) ? <Loading /> : <div> </div>}
+      </div>
+  )
+}
+
+export default Redirection

--- a/gible/src/config/loginConfig.js
+++ b/gible/src/config/loginConfig.js
@@ -1,0 +1,7 @@
+const loginConfig = {
+    REST_API_KEY: process.env.REACT_APP_REST_API_KEY,
+    REDIRECT_URI: process.env.REACT_APP_REDIRECT_URI,
+    CLIENT_ID: process.env.REACT_APP_CLIENT_ID
+}
+
+export default loginConfig;

--- a/gible/src/config/loginConfig.js
+++ b/gible/src/config/loginConfig.js
@@ -1,7 +1,6 @@
 const loginConfig = {
     REST_API_KEY: process.env.REACT_APP_REST_API_KEY,
     REDIRECT_URI: process.env.REACT_APP_REDIRECT_URI,
-    CLIENT_ID: process.env.REACT_APP_CLIENT_ID
 }
 
 export default loginConfig;

--- a/gible/src/layouts/Loading.js
+++ b/gible/src/layouts/Loading.js
@@ -1,0 +1,38 @@
+import styled, { keyframes } from 'styled-components';
+
+const moving = keyframes`
+  50% {
+    width: 100%;
+  }
+
+  100% {
+    width: 0;
+    right: 0;
+    left: unset;
+  }
+`;
+
+const Loading = styled.div`
+  display: block;
+  --height-of-loader: 4px;
+  --loader-color: #ff0000;
+  width: 130px;
+  height: var(--height-of-loader);
+  border-radius: 30px;
+  background-color: rgba(0, 0, 0, 0.2);
+  position: relative;
+
+  &::before {
+    content: "";
+    position: absolute;
+    background: var(--loader-color);
+    top: 0;
+    left: 0;
+    width: 0%;
+    height: 100%;
+    border-radius: 30px;
+    animation: ${moving} 1s ease-in-out infinite;
+  }
+`;
+
+export default Loading;


### PR DESCRIPTION
## 개요
카카오 소셜 로그인 시 Redirect URI로 오는 응답을 받아 백엔드로 인가 코드, 클라이언트 id를 전달하는 환경 구축

## 구현
- `/kakaologin`으로 오는 Redirect URI를 받은 뒤 작업을 수행하는 `<Redirection />` 컴포넌트 생성
- 로그인 관련 필요 환경 변수를 담은 loginConfig.js 생성
## 기타
헤더, 푸터 머지되면 로그인 컴포넌트도 머지시킨 다음 버튼 클릭 시 카카오 로그인 화면으로 넘어가도록 연동시키겠습니다.

- axios 변수명 충돌로 인한 api 전역 인스턴스 변수명 변경 : `axios` -> `apiClient`
- 로딩 컴포넌트 추가