### PR TITLE
HF-53: 로그인 후 응답에 따른 처리 로직 추가

### DIFF
--- a/gible/src/api/axios.js
+++ b/gible/src/api/axios.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { apiServer } from '@/config/api'
 
 const apiClient = axios.create({
-    baseURL: apiServer
+    baseURL: apiServer,
 })
 
 export default apiClient;

--- a/gible/src/api/login/loginResponseHandler.js
+++ b/gible/src/api/login/loginResponseHandler.js
@@ -1,7 +1,7 @@
 import apiClient from "@/api/axios";
 import loginConfig from "@/config/loginConfig";
 import { setAccessToken, setRefreshToken } from "@/store/authSlice";
-import store from '@/store/store';
+import store from '/store/store';
 
 const loginResponseHandler = async (dispatch, code) => {
     
@@ -14,16 +14,16 @@ const loginResponseHandler = async (dispatch, code) => {
         console.log('responseStatus',response.status);
 
         if (response.data.statusCode === 510) { // 추가 정보 필요
-            dispatch(setAccessToken(response.data.accessToken));
-            dispatch(setRefreshToken(response.data.refreshToken));
-            const state = store.getState();
-            console.log(state);
             return {
                 statusCode: response.data.statusCode,
                 // message
             }
         }
         else {                                  // 로그인
+            dispatch(setAccessToken(response.data.accessToken));
+            dispatch(setRefreshToken(response.data.refreshToken));
+            const state = store.getState();
+            console.log(state);
             return {
                 statusCode: response.status,
                 // message

--- a/gible/src/api/login/loginResponseHandler.js
+++ b/gible/src/api/login/loginResponseHandler.js
@@ -1,0 +1,42 @@
+import apiClient from "@/api/axios";
+import loginConfig from "@/config/loginConfig";
+import { setAccessToken, setRefreshToken } from "@/store/authSlice";
+import store from '@/store/store';
+
+const loginResponseHandler = async (dispatch, code) => {
+    
+    try {
+        const response = await apiClient.post('auth/kakaologin', {
+            clientId: loginConfig.REST_API_KEY,
+            code
+        });
+        console.log('response', response);
+        console.log('responseStatus',response.status);
+
+        if (response.data.statusCode === 510) { // 추가 정보 필요
+            dispatch(setAccessToken(response.data.accessToken));
+            dispatch(setRefreshToken(response.data.refreshToken));
+            const state = store.getState();
+            console.log(state);
+            return {
+                statusCode: response.data.statusCode,
+                // message
+            }
+        }
+        else {                                  // 로그인
+            return {
+                statusCode: response.status,
+                // message
+            }
+        }
+
+    } catch (error) {
+        console.log('error',error);
+        return {
+            statusCode: error.response.status
+            // message
+        };
+    }
+}
+
+export default loginResponseHandler;

--- a/gible/src/components/login/Redirection.js
+++ b/gible/src/components/login/Redirection.js
@@ -1,32 +1,46 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom';
-import loginConfig from '@/config/loginConfig'
-import apiClient from '@/api/axios';
 import Loading from '@/layouts/Loading';
+import loginResponseHandler from '@/api/login/loginResponseHandler';
+import styled from 'styled-components';
+import { useDispatch } from 'react-redux';
+
 
 const Redirection = () => {
     const code = new URL(document.location.toString()).searchParams.get('code');
-    const navigate = useNavigate();
     const [isLoaded, setIsLoaded] = useState(false);
+    const navigate = useNavigate();
+    const dispatch = useDispatch();
   
+    const HandleloginResponse = async () => {
+      const result = await loginResponseHandler(dispatch, code);
+      if (result.statusCode === 200) {    
+        setIsLoaded(true);
+        navigate('/');
+      }
+      else if (result.statusCode === 510)
+        navigate('/signup');
+      else
+        navigate('/error');
+    }
+
     useEffect(() => {
-        /*
-          apiClient.post('/kakaologin', {
-            clientId : loginConfig.REST_API_KEY,
-            code
-          })
-        */
-      
-        // response받아서 setIsLoaded 호출
-      alert('loginSucceed');
-      navigate('/');
-    }, [])
+      HandleloginResponse();
+    },[])
+
 
   return (
-      <div>
+      <Wrapper>
         {(!isLoaded) ? <Loading /> : <div> </div>}
-      </div>
+      </Wrapper>
   )
 }
+
+const Wrapper = styled.div`
+  width : 100%;
+  display : flex;
+  justify-content : center;
+  align-items : center;
+`;
 
 export default Redirection

--- a/gible/src/config/api.js
+++ b/gible/src/config/api.js
@@ -1,1 +1,1 @@
-export const apiServer = process.env.REACT_APP_API_SERVER;
+export const apiServer = process.env.REACT_APP_BASE_URL;

--- a/gible/src/pages/error/Error.js
+++ b/gible/src/pages/error/Error.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const Error = () => {
+  return (
+      <Wrapper>
+          <Title>ERROR 404</Title>
+          <Description>페이지를 찾을 수 없습니다.</Description>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div`
+    width : 100%;
+    display : flex;
+    flex-direction : column;
+    justify-content : center;
+    align-items : center;
+    gap : 30px;
+    color : var(--main-color);
+`;
+
+const Title = styled.div`
+    font-size : 50px;
+    font-weight : 1000;
+`
+
+const Description = styled.div`
+    font-size : 35px;
+    font-weight : bold;
+    color : #111;
+`
+
+export default Error


### PR DESCRIPTION
## 개요
- 로그인 후 응답에 따른 처리 로직 추가

## 구현
- `<Redirection>` 컴포넌트 수정, `loginResponseHandler()` 수정
   - 로그인 후 응답 status code : 200일 때 access token/refresh token 리덕스 state로 추가
   - 로그인 후 응답 status code : 510일 때 `/singup` 페이지로 이동
## 기타
- HF-53은 회원가입 api 작성이지만 우선 로그인 후 응답에 따른 처리 과정까지만 작성하였습니다. 일요일 회의 이후 회원가입 시 필요 dto 정확히 논의 후에 api 추가 작성하여 커밋하겠습니다.